### PR TITLE
PF-1096: Adds support for PR- and Jira links in release notes

### DIFF
--- a/get-release-notes/README.md
+++ b/get-release-notes/README.md
@@ -15,6 +15,12 @@ To use this action, you need to provide the following inputs:
 - `head`: Head commit SHA (required)
 - `base`: Base commit SHA (required)
 - `github-token`: GitHub token for authentication (required)
+- `show-pull-request-links`: Show PR numbers as links (optional, default: false)
+- `pull-request-base-url`: Pull-request base URL (optional, but required if
+  show-pull-request-links = true)
+- `show-jira-links`: Show Jira IDs as links (optional, default: false)
+- `jira-base-url`: Jira base URL (optional, but required if show-jira-links =
+  true)
 
 ## Example Workflow
 
@@ -41,6 +47,10 @@ jobs:
           head: ${{ github.event.after }}
           base: ${{ github.event.before }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          show-pull-request-links: true
+          pull-request-base-url: https://your-pull-request-url.com
+          show-jira-links: true
+          jira-base-url: https://your-jira-url.com
 
       - name: Display Release Notes
         run: echo "${{ steps.release-notes.outputs.release-notes }}"
@@ -63,6 +73,22 @@ Base commit SHA to compare.
 ### `github-token`
 
 GitHub token for authentication.
+
+### `show-pull-request-links`
+
+Show PR numbers as links.
+
+### `pull-request-base-url`
+
+Pull-request base URL.
+
+### `show-jira-links`
+
+Show Jira IDs as links.
+
+### `jira-base-url`
+
+Jira base URL.
 
 ## Outputs
 

--- a/get-release-notes/__mocks__/@actions/core.ts
+++ b/get-release-notes/__mocks__/@actions/core.ts
@@ -8,8 +8,22 @@ export function getInput(name: string): string {
       return "mocked-head";
     case "github-token":
       return "mocked-github-token";
+    case "pull-request-base-url":
+      return "mocked-pull-request-base-url";
+    case "jira-base-url":
+      return "mocked-jira-base-url";
     default:
       return "";
+  }
+}
+
+export function getBooleanInput(name: string): boolean {
+  switch (name) {
+    case "show-pull-request-links":
+    case "show-jira-links":
+      return true;
+    default:
+      return false;
   }
 }
 

--- a/get-release-notes/__tests__/inputs-helper.test.ts
+++ b/get-release-notes/__tests__/inputs-helper.test.ts
@@ -8,22 +8,32 @@ jest.mock("@actions/core");
 describe("loadInputs", () => {
   it("loads inputs correctly", () => {
     // act
-    const { repository, head, base, githubToken }: Inputs =
-      InputsHelpers.loadInputs();
+    const {
+      repository,
+      head,
+      base,
+      githubToken,
+      showPullRequestLinks,
+      pullRequestBaseUrl,
+      showJiraLinks,
+      jiraBaseUrl
+    }: Inputs = InputsHelpers.loadInputs();
 
     // assert
     expect(repository).toBe("mocked-repository");
     expect(head).toBe("mocked-head");
     expect(base).toBe("mocked-base");
     expect(githubToken).toBe("mocked-github-token");
+    expect(showPullRequestLinks).toBe(true);
+    expect(pullRequestBaseUrl).toBe("mocked-pull-request-base-url");
+    expect(showJiraLinks).toBe(true);
+    expect(jiraBaseUrl).toBe("mocked-jira-base-url");
   });
 
   it("loads default values", () => {
     // arrange
     jest.spyOn(core, "getInput").mockImplementation((name: string) => {
-      if (name === "product") {
-        return "mocked-product";
-      } else if (name === "release-notes") {
+      if (name === "release-notes") {
         return '[""]';
       } else {
         return "";
@@ -31,13 +41,25 @@ describe("loadInputs", () => {
     });
 
     // act
-    const { repository, head, base, githubToken }: Inputs =
-      InputsHelpers.loadInputs();
+    const {
+      repository,
+      head,
+      base,
+      githubToken,
+      showPullRequestLinks,
+      pullRequestBaseUrl,
+      showJiraLinks,
+      jiraBaseUrl
+    }: Inputs = InputsHelpers.loadInputs();
 
     // assert
     expect(repository).toBe("");
     expect(head).toBe("");
     expect(base).toBe("");
     expect(githubToken).toBe("");
+    expect(showPullRequestLinks).toBe(true);
+    expect(pullRequestBaseUrl).toBe("");
+    expect(showJiraLinks).toBe(true);
+    expect(jiraBaseUrl).toBe("");
   });
 });

--- a/get-release-notes/__tests__/links-helper.test.ts
+++ b/get-release-notes/__tests__/links-helper.test.ts
@@ -17,19 +17,19 @@ describe("addPullRequestLinks", () => {
 
     // assert
     expect(result[0]).toBe(
-      `MP-526: Kombinert NoHandler- og NoResource-Exception til en. Fjernet logging av stack-trace. (<a href="${baseUrl}/pull/432" target="_blank">#432</a>)`
+      `MP-526: Kombinert NoHandler- og NoResource-Exception til en. Fjernet logging av stack-trace. ([#432](${baseUrl}/pull/432))`
     );
 
     expect(result[1]).toBe(
-      `MP-499: Legge til security.txt (<a href="${baseUrl}/pull/433" target="_blank">#433</a>)`
+      `MP-499: Legge til security.txt ([#433](${baseUrl}/pull/433))`
     );
 
     expect(result[2]).toBe(
-      `MP-511: Legg til source rammeverk og triggering av rett source authorization (<a href="${baseUrl}/pull/429" target="_blank">#429</a>)`
+      `MP-511: Legg til source rammeverk og triggering av rett source authorization ([#429](${baseUrl}/pull/429))`
     );
 
     expect(result[3]).toBe(
-      `MP-503: Legg til model og interface for authorization_details (<a href="${baseUrl}/pull/425" target="_blank">#425</a>)`
+      `MP-503: Legg til model og interface for authorization_details ([#425](${baseUrl}/pull/425))`
     );
   });
 
@@ -59,14 +59,12 @@ describe("addPullRequestLinks", () => {
     const result = addPullRequestLinks(baseUrl, releaseNotes);
 
     // assert
-    expect(result[0]).toBe(
-      `Fix some bugs (<a href="${baseUrl}/pull/123" target="_blank">#123</a>)`
-    );
+    expect(result[0]).toBe(`Fix some bugs ([#123](${baseUrl}/pull/123))`);
 
     expect(result[1]).toBe("Add feature MP-123");
 
     expect(result[2]).toBe(
-      `Update documentation (<a href="${baseUrl}/pull/456" target="_blank">#456</a>)`
+      `Update documentation ([#456](${baseUrl}/pull/456))`
     );
   });
 });
@@ -86,20 +84,20 @@ describe("addJiraLinks", () => {
     const result = addJiraLinks(baseUrl, releaseNotes);
 
     // assert
-    expect(result[0]).toContain(
-      `<a href="${baseUrl}/browse/MP-526" target="_blank">MP-526</a>`
+    expect(result[0]).toBe(
+      `[MP-526](${baseUrl}/browse/MP-526): Kombinert NoHandler- og NoResource-Exception til en. Fjernet logging av stack-trace. (#432)`
     );
 
-    expect(result[1]).toContain(
-      `<a href="${baseUrl}/browse/MP-499" target="_blank">MP-499</a>`
+    expect(result[1]).toBe(
+      `[MP-499](${baseUrl}/browse/MP-499): Legge til security.txt (#433)`
     );
 
-    expect(result[2]).toContain(
-      `<a href="${baseUrl}/browse/MP-511" target="_blank">MP-511</a>`
+    expect(result[2]).toBe(
+      `[MP-511](${baseUrl}/browse/MP-511): Legg til source rammeverk og triggering av rett source authorization (#429)`
     );
 
-    expect(result[3]).toContain(
-      `<a href="${baseUrl}/browse/MP-503" target="_blank">MP-503</a>`
+    expect(result[3]).toBe(
+      `[MP-503](${baseUrl}/browse/MP-503): Legg til model og interface for authorization_details (#425)`
     );
   });
 
@@ -131,7 +129,7 @@ describe("addJiraLinks", () => {
     // assert
     expect(result[0]).toBe("Fix some bugs (#123)");
     expect(result[1]).toContain(
-      `Add feature <a href="${baseUrl}/browse/MP-123" target="_blank">MP-123</a>`
+      `Add feature [MP-123](${baseUrl}/browse/MP-123)`
     );
     expect(result[2]).toBe("Update documentation (#456)");
   });

--- a/get-release-notes/__tests__/links-helper.test.ts
+++ b/get-release-notes/__tests__/links-helper.test.ts
@@ -83,19 +83,19 @@ describe("addJiraLinks", () => {
 
     // assert
     expect(result[0]).toBe(
-      `[MP-526](${baseUrl}/browse/MP-526): Kombinert NoHandler- og NoResource-Exception til en. Fjernet logging av stack-trace. (#432)`
+      `[MP-526](${baseUrl}/MP-526): Kombinert NoHandler- og NoResource-Exception til en. Fjernet logging av stack-trace. (#432)`
     );
 
     expect(result[1]).toBe(
-      `[MP-499](${baseUrl}/browse/MP-499): Legge til security.txt (#433)`
+      `[MP-499](${baseUrl}/MP-499): Legge til security.txt (#433)`
     );
 
     expect(result[2]).toBe(
-      `[MP-511](${baseUrl}/browse/MP-511): Legg til source rammeverk og triggering av rett source authorization (#429)`
+      `[MP-511](${baseUrl}/MP-511): Legg til source rammeverk og triggering av rett source authorization (#429)`
     );
 
     expect(result[3]).toBe(
-      `[MP-503](${baseUrl}/browse/MP-503): Legg til model og interface for authorization_details (#425)`
+      `[MP-503](${baseUrl}/MP-503): Legg til model og interface for authorization_details (#425)`
     );
   });
 
@@ -126,9 +126,7 @@ describe("addJiraLinks", () => {
 
     // assert
     expect(result[0]).toBe("Fix some bugs (#123)");
-    expect(result[1]).toContain(
-      `Add feature [MP-123](${baseUrl}/browse/MP-123)`
-    );
+    expect(result[1]).toContain(`Add feature [MP-123](${baseUrl}/MP-123)`);
     expect(result[2]).toBe("Update documentation (#456)");
   });
 });

--- a/get-release-notes/__tests__/links-helper.test.ts
+++ b/get-release-notes/__tests__/links-helper.test.ts
@@ -17,19 +17,19 @@ describe("addPullRequestLinks", () => {
 
     // assert
     expect(result[0]).toBe(
-      `MP-526: Kombinert NoHandler- og NoResource-Exception til en. Fjernet logging av stack-trace. ([#432](${baseUrl}/pull/432))`
+      `MP-526: Kombinert NoHandler- og NoResource-Exception til en. Fjernet logging av stack-trace. ([#432](${baseUrl}/432))`
     );
 
     expect(result[1]).toBe(
-      `MP-499: Legge til security.txt ([#433](${baseUrl}/pull/433))`
+      `MP-499: Legge til security.txt ([#433](${baseUrl}/433))`
     );
 
     expect(result[2]).toBe(
-      `MP-511: Legg til source rammeverk og triggering av rett source authorization ([#429](${baseUrl}/pull/429))`
+      `MP-511: Legg til source rammeverk og triggering av rett source authorization ([#429](${baseUrl}/429))`
     );
 
     expect(result[3]).toBe(
-      `MP-503: Legg til model og interface for authorization_details ([#425](${baseUrl}/pull/425))`
+      `MP-503: Legg til model og interface for authorization_details ([#425](${baseUrl}/425))`
     );
   });
 
@@ -59,13 +59,11 @@ describe("addPullRequestLinks", () => {
     const result = addPullRequestLinks(baseUrl, releaseNotes);
 
     // assert
-    expect(result[0]).toBe(`Fix some bugs ([#123](${baseUrl}/pull/123))`);
+    expect(result[0]).toBe(`Fix some bugs ([#123](${baseUrl}/123))`);
 
     expect(result[1]).toBe("Add feature MP-123");
 
-    expect(result[2]).toBe(
-      `Update documentation ([#456](${baseUrl}/pull/456))`
-    );
+    expect(result[2]).toBe(`Update documentation ([#456](${baseUrl}/456))`);
   });
 });
 

--- a/get-release-notes/__tests__/links-helper.test.ts
+++ b/get-release-notes/__tests__/links-helper.test.ts
@@ -1,0 +1,138 @@
+import { addJiraLinks, addPullRequestLinks } from "../src/helpers/links-helper";
+import { describe, it, expect } from "@jest/globals";
+
+describe("addPullRequestLinks", () => {
+  it("replaces Jira IDs and pull-request numbers with links", () => {
+    // arrange
+    const baseUrl = "https://your-jira-instance.com";
+    const releaseNotes = [
+      "MP-526: Kombinert NoHandler- og NoResource-Exception til en. Fjernet logging av stack-trace. (#432)",
+      "MP-499: Legge til security.txt (#433)",
+      "MP-511: Legg til source rammeverk og triggering av rett source authorization (#429)",
+      "MP-503: Legg til model og interface for authorization_details (#425)"
+    ];
+
+    // act
+    const result = addPullRequestLinks(baseUrl, releaseNotes);
+
+    // assert
+    expect(result[0]).toBe(
+      `MP-526: Kombinert NoHandler- og NoResource-Exception til en. Fjernet logging av stack-trace. (<a href="${baseUrl}/pull/432" target="_blank">#432</a>)`
+    );
+
+    expect(result[1]).toBe(
+      `MP-499: Legge til security.txt (<a href="${baseUrl}/pull/433" target="_blank">#433</a>)`
+    );
+
+    expect(result[2]).toBe(
+      `MP-511: Legg til source rammeverk og triggering av rett source authorization (<a href="${baseUrl}/pull/429" target="_blank">#429</a>)`
+    );
+
+    expect(result[3]).toBe(
+      `MP-503: Legg til model og interface for authorization_details (<a href="${baseUrl}/pull/425" target="_blank">#425</a>)`
+    );
+  });
+
+  it("handles release notes with no Jira IDs or pull-request numbers", () => {
+    // arrange
+    const baseUrl = "https://your-jira-instance.com";
+    const releaseNotes = ["Fix 12 bugs", "Update documentation"];
+
+    // act
+    const result = addPullRequestLinks(baseUrl, releaseNotes);
+
+    // assert
+    expect(result[0]).toBe("Fix 12 bugs");
+    expect(result[1]).toBe("Update documentation");
+  });
+
+  it("handles release notes with mixed content", () => {
+    // arrange
+    const baseUrl = "https://your-jira-instance.com";
+    const releaseNotes = [
+      "Fix some bugs (#123)",
+      "Add feature MP-123",
+      "Update documentation (#456)"
+    ];
+
+    // act
+    const result = addPullRequestLinks(baseUrl, releaseNotes);
+
+    // assert
+    expect(result[0]).toBe(
+      `Fix some bugs (<a href="${baseUrl}/pull/123" target="_blank">#123</a>)`
+    );
+
+    expect(result[1]).toBe("Add feature MP-123");
+
+    expect(result[2]).toBe(
+      `Update documentation (<a href="${baseUrl}/pull/456" target="_blank">#456</a>)`
+    );
+  });
+});
+
+describe("addJiraLinks", () => {
+  it("replaces Jira IDs and pull-request numbers with links", () => {
+    // arrange
+    const baseUrl = "https://your-jira-instance.com";
+    const releaseNotes = [
+      "MP-526: Kombinert NoHandler- og NoResource-Exception til en. Fjernet logging av stack-trace. (#432)",
+      "MP-499: Legge til security.txt (#433)",
+      "MP-511: Legg til source rammeverk og triggering av rett source authorization (#429)",
+      "MP-503: Legg til model og interface for authorization_details (#425)"
+    ];
+
+    // act
+    const result = addJiraLinks(baseUrl, releaseNotes);
+
+    // assert
+    expect(result[0]).toContain(
+      `<a href="${baseUrl}/browse/MP-526" target="_blank">MP-526</a>`
+    );
+
+    expect(result[1]).toContain(
+      `<a href="${baseUrl}/browse/MP-499" target="_blank">MP-499</a>`
+    );
+
+    expect(result[2]).toContain(
+      `<a href="${baseUrl}/browse/MP-511" target="_blank">MP-511</a>`
+    );
+
+    expect(result[3]).toContain(
+      `<a href="${baseUrl}/browse/MP-503" target="_blank">MP-503</a>`
+    );
+  });
+
+  it("handles release notes with no Jira IDs or pull-request numbers", () => {
+    // arrange
+    const baseUrl = "https://your-jira-instance.com";
+    const releaseNotes = ["Fix 12 bugs", "Update documentation"];
+
+    // act
+    const result = addJiraLinks(baseUrl, releaseNotes);
+
+    // assert
+    expect(result[0]).toBe("Fix 12 bugs");
+    expect(result[1]).toBe("Update documentation");
+  });
+
+  it("handles release notes with mixed content", () => {
+    // arrange
+    const baseUrl = "https://your-jira-instance.com";
+    const releaseNotes = [
+      "Fix some bugs (#123)",
+      "Add feature MP-123",
+      "Update documentation (#456)"
+    ];
+
+    // act
+    const result = addJiraLinks(baseUrl, releaseNotes);
+
+    // assert
+    expect(result[0]).toBe("Fix some bugs (#123)");
+    expect(result[1]).toContain(
+      `Add feature <a href="${baseUrl}/browse/MP-123" target="_blank">MP-123</a>`
+    );
+    expect(result[2]).toBe("Update documentation (#456)");
+  });
+});

--- a/get-release-notes/__tests__/main.test.ts
+++ b/get-release-notes/__tests__/main.test.ts
@@ -42,7 +42,11 @@ describe("run", () => {
       repository: "owner/repo",
       head: "head",
       base: "base",
-      githubToken: "token"
+      githubToken: "token",
+      showPullRequestLinks: true,
+      pullRequestBaseUrl: "https://github.com/company/repo/",
+      showJiraLinks: true,
+      jiraBaseUrl: "https://company.atlassian.net/"
     };
     jest.spyOn(InputsHelpers, "loadInputs").mockReturnValue(mockInputs);
     jest.spyOn(core, "setOutput");

--- a/get-release-notes/action.yml
+++ b/get-release-notes/action.yml
@@ -19,6 +19,24 @@ inputs:
     description:
     required: true
     type: string
+  show-pull-request-links:
+    description: Show PR numbers as links
+    required: false
+    default: false
+    type: boolean
+  pull-request-base-url:
+    description: Pull-request base URL
+    required: false
+    type: string
+  show-jira-links:
+    description;: Show Jira IDs as links
+    required: false
+    default: false
+    type: boolean
+  jira-base-url:
+    description: Jira base URL
+    required: false
+    type: string
 
 outputs:
   release-notes:

--- a/get-release-notes/dist/index.js
+++ b/get-release-notes/dist/index.js
@@ -29280,7 +29280,7 @@ function addJiraLinks(baseUrl, releaseNotes) {
     return releaseNotes.map(note => {
         // Replace Jira IDs with links
         return note.replace(jiraRegex, jiraId => {
-            return `[${jiraId}](${baseUrl}/browse/${jiraId})`;
+            return `[${jiraId}](${baseUrl}/${jiraId})`;
         });
     });
 }

--- a/get-release-notes/dist/index.js
+++ b/get-release-notes/dist/index.js
@@ -29264,7 +29264,7 @@ function addPullRequestLinks(baseUrl, releaseNotes) {
     return releaseNotes.map(note => {
         // Replace pull-request numbers with links
         return note.replace(prRegex, prNumber => {
-            return `[${prNumber}](${baseUrl}/pull/${prNumber.slice(1)})`;
+            return `[${prNumber}](${baseUrl}/${prNumber.slice(1)})`;
         });
     });
 }

--- a/get-release-notes/dist/index.js
+++ b/get-release-notes/dist/index.js
@@ -29225,15 +29225,19 @@ function loadInputs() {
     const base = core.getInput("base", { required: true });
     const githubToken = core.getInput("github-token", { required: true });
     const showPullRequestLinks = core.getBooleanInput("show-pull-request-links", { required: false });
-    const pullRequestBaseUrl = core.getInput("pull-request-base-url", {
-        required: false
-    });
+    let pullRequestBaseUrl = "";
+    if (showPullRequestLinks) {
+        pullRequestBaseUrl = core.getInput("pull-request-base-url", {
+            required: true
+        });
+    }
     const showJiraLinks = core.getBooleanInput("show-jira-links", {
         required: false
     });
-    const jiraBaseUrl = core.getInput("jira-base-url", {
-        required: false
-    });
+    let jiraBaseUrl = "";
+    if (showJiraLinks) {
+        jiraBaseUrl = core.getInput("jira-base-url", { required: true });
+    }
     return {
         repository,
         head,

--- a/get-release-notes/dist/index.js
+++ b/get-release-notes/dist/index.js
@@ -29264,7 +29264,7 @@ function addPullRequestLinks(baseUrl, releaseNotes) {
     return releaseNotes.map(note => {
         // Replace pull-request numbers with links
         return note.replace(prRegex, prNumber => {
-            return `<a href="${baseUrl}/pull/${prNumber.slice(1)}" target="_blank">${prNumber}</a>`;
+            return `[${prNumber}](${baseUrl}/pull/${prNumber.slice(1)})`;
         });
     });
 }
@@ -29276,7 +29276,7 @@ function addJiraLinks(baseUrl, releaseNotes) {
     return releaseNotes.map(note => {
         // Replace Jira IDs with links
         return note.replace(jiraRegex, jiraId => {
-            return `<a href="${baseUrl}/browse/${jiraId}" target="_blank">${jiraId}</a>`;
+            return `[${jiraId}](${baseUrl}/browse/${jiraId})`;
         });
     });
 }

--- a/get-release-notes/src/helpers/inputs-helper.ts
+++ b/get-release-notes/src/helpers/inputs-helper.ts
@@ -12,7 +12,7 @@ export function loadInputs(): Inputs {
     { required: false }
   );
 
-  let pullRequestBaseUrl: string = "";
+  let pullRequestBaseUrl = "";
   if (showPullRequestLinks) {
     pullRequestBaseUrl = core.getInput("pull-request-base-url", {
       required: true
@@ -23,7 +23,7 @@ export function loadInputs(): Inputs {
     required: false
   });
 
-  let jiraBaseUrl: string = "";
+  let jiraBaseUrl = "";
   if (showJiraLinks) {
     jiraBaseUrl = core.getInput("jira-base-url", { required: true });
   }

--- a/get-release-notes/src/helpers/inputs-helper.ts
+++ b/get-release-notes/src/helpers/inputs-helper.ts
@@ -12,17 +12,21 @@ export function loadInputs(): Inputs {
     { required: false }
   );
 
-  const pullRequestBaseUrl: string = core.getInput("pull-request-base-url", {
-    required: false
-  });
+  let pullRequestBaseUrl: string = "";
+  if (showPullRequestLinks) {
+    pullRequestBaseUrl = core.getInput("pull-request-base-url", {
+      required: true
+    });
+  }
 
   const showJiraLinks: boolean = core.getBooleanInput("show-jira-links", {
     required: false
   });
 
-  const jiraBaseUrl: string = core.getInput("jira-base-url", {
-    required: false
-  });
+  let jiraBaseUrl: string = "";
+  if (showJiraLinks) {
+    jiraBaseUrl = core.getInput("jira-base-url", { required: true });
+  }
 
   return {
     repository,

--- a/get-release-notes/src/helpers/inputs-helper.ts
+++ b/get-release-notes/src/helpers/inputs-helper.ts
@@ -7,10 +7,31 @@ export function loadInputs(): Inputs {
   const base: string = core.getInput("base", { required: true });
   const githubToken: string = core.getInput("github-token", { required: true });
 
+  const showPullRequestLinks: boolean = core.getBooleanInput(
+    "show-pull-request-links",
+    { required: false }
+  );
+
+  const pullRequestBaseUrl: string = core.getInput("pull-request-base-url", {
+    required: false
+  });
+
+  const showJiraLinks: boolean = core.getBooleanInput("show-jira-links", {
+    required: false
+  });
+
+  const jiraBaseUrl: string = core.getInput("jira-base-url", {
+    required: false
+  });
+
   return {
     repository,
     head,
     base,
-    githubToken
+    githubToken,
+    showPullRequestLinks,
+    pullRequestBaseUrl,
+    showJiraLinks,
+    jiraBaseUrl
   };
 }

--- a/get-release-notes/src/helpers/links-helper.ts
+++ b/get-release-notes/src/helpers/links-helper.ts
@@ -9,7 +9,7 @@ export function addPullRequestLinks(
   return releaseNotes.map(note => {
     // Replace pull-request numbers with links
     return note.replace(prRegex, prNumber => {
-      return `[${prNumber}](${baseUrl}/pull/${prNumber.slice(1)})`;
+      return `[${prNumber}](${baseUrl}/${prNumber.slice(1)})`;
     });
   });
 }

--- a/get-release-notes/src/helpers/links-helper.ts
+++ b/get-release-notes/src/helpers/links-helper.ts
@@ -25,7 +25,7 @@ export function addJiraLinks(
   return releaseNotes.map(note => {
     // Replace Jira IDs with links
     return note.replace(jiraRegex, jiraId => {
-      return `[${jiraId}](${baseUrl}/browse/${jiraId})`;
+      return `[${jiraId}](${baseUrl}/${jiraId})`;
     });
   });
 }

--- a/get-release-notes/src/helpers/links-helper.ts
+++ b/get-release-notes/src/helpers/links-helper.ts
@@ -9,7 +9,7 @@ export function addPullRequestLinks(
   return releaseNotes.map(note => {
     // Replace pull-request numbers with links
     return note.replace(prRegex, prNumber => {
-      return `<a href="${baseUrl}/pull/${prNumber.slice(1)}" target="_blank">${prNumber}</a>`;
+      return `[${prNumber}](${baseUrl}/pull/${prNumber.slice(1)})`;
     });
   });
 }
@@ -25,7 +25,7 @@ export function addJiraLinks(
   return releaseNotes.map(note => {
     // Replace Jira IDs with links
     return note.replace(jiraRegex, jiraId => {
-      return `<a href="${baseUrl}/browse/${jiraId}" target="_blank">${jiraId}</a>`;
+      return `[${jiraId}](${baseUrl}/browse/${jiraId})`;
     });
   });
 }

--- a/get-release-notes/src/helpers/links-helper.ts
+++ b/get-release-notes/src/helpers/links-helper.ts
@@ -1,0 +1,31 @@
+export function addPullRequestLinks(
+  baseUrl: string,
+  releaseNotes: string[]
+): string[] {
+  // Regular expression to match pull-request numbers
+  const prRegex = /#\d+/g;
+
+  // Iterate over each release note
+  return releaseNotes.map(note => {
+    // Replace pull-request numbers with links
+    return note.replace(prRegex, prNumber => {
+      return `<a href="${baseUrl}/pull/${prNumber.slice(1)}" target="_blank">${prNumber}</a>`;
+    });
+  });
+}
+
+export function addJiraLinks(
+  baseUrl: string,
+  releaseNotes: string[]
+): string[] {
+  // Regular expression to match the pattern <alpha><alpha><alpha>-<number><number><number>
+  const jiraRegex = /\b[A-Za-z]{2,3}-\d{1,4}\b/g;
+
+  // Iterate over each release note
+  return releaseNotes.map(note => {
+    // Replace Jira IDs with links
+    return note.replace(jiraRegex, jiraId => {
+      return `<a href="${baseUrl}/browse/${jiraId}" target="_blank">${jiraId}</a>`;
+    });
+  });
+}

--- a/get-release-notes/src/interfaces/inputs.ts
+++ b/get-release-notes/src/interfaces/inputs.ts
@@ -3,4 +3,8 @@ export interface Inputs {
   head: string;
   base: string;
   githubToken: string;
+  showPullRequestLinks: boolean;
+  pullRequestBaseUrl: string;
+  showJiraLinks: boolean;
+  jiraBaseUrl: string;
 }

--- a/get-release-notes/src/main.ts
+++ b/get-release-notes/src/main.ts
@@ -2,17 +2,34 @@ import * as core from "@actions/core";
 import * as InputsHelpers from "./helpers/inputs-helper";
 import { Commit, Inputs } from "./interfaces";
 import ReleaseNotesClient from "./release-notes";
+import { addPullRequestLinks, addJiraLinks } from "./helpers/links-helper";
 
 export async function run(): Promise<void> {
   try {
-    const { repository, head, base, githubToken }: Inputs =
-      InputsHelpers.loadInputs();
+    const {
+      repository,
+      head,
+      base,
+      githubToken,
+      showPullRequestLinks,
+      pullRequestBaseUrl,
+      showJiraLinks,
+      jiraBaseUrl
+    }: Inputs = InputsHelpers.loadInputs();
 
     const client = new ReleaseNotesClient(repository, base, head, githubToken);
 
     const commits: Commit[] = await client.retrieveReleaseNotes();
 
-    const releaseNotes = commits.map(c => c.message);
+    let releaseNotes = commits.map(c => c.message);
+
+    if (showPullRequestLinks) {
+      releaseNotes = addPullRequestLinks(pullRequestBaseUrl, releaseNotes);
+    }
+
+    if (showJiraLinks) {
+      releaseNotes = addJiraLinks(jiraBaseUrl, releaseNotes);
+    }
 
     core.setOutput("release-notes", releaseNotes);
   } catch (error) {


### PR DESCRIPTION
Adds new inputs for:
`show-pull-request-links`: Show PR numbers as links.

`pull-request-base-url`: Pull-request base URL.

`show-jira-links`: Show Jira IDs as links.

`jira-base-url`: Jira base URL.

Test run:
https://github.com/felleslosninger/plattform-test-cd/actions/runs/8970476553/job/24634151379