### PR TITLE
PF-1227: Adds support for allow-products and allow-applications inputs

### DIFF
--- a/publish-release-notes/README.md
+++ b/publish-release-notes/README.md
@@ -84,6 +84,22 @@ release notes.
   - **Required**: true
   - **Type**: string
 
+- `allow-products`:
+
+  - **Description**: List of products allowed to trigger release notes
+    generation.
+  - **Required**: false
+  - **Default**: ""
+  - **Type**: string
+
+- `allow-applications`:
+
+  - **Description**: List of applications allowed to trigger release notes
+    generation.
+  - **Required**: false
+  - **Default**: ""
+  - **Type**: string
+
 - `ignore-products`:
 
   - **Description**: Comma seperated list of product(s) to ignore when

--- a/publish-release-notes/__mocks__/@actions/core.ts
+++ b/publish-release-notes/__mocks__/@actions/core.ts
@@ -1,3 +1,5 @@
+import { jest } from "@jest/globals";
+
 export function getInput(name: string): string {
   switch (name) {
     case "application-name":
@@ -8,6 +10,10 @@ export function getInput(name: string): string {
       return "mocked-event-type";
     case "github-token":
       return "mocked-github-token";
+    case "allow-applications":
+      return "";
+    case "allow-products":
+      return "";
     case "ignore-applications":
       return "mocked-ignore-applications";
     case "ignore-commits":

--- a/publish-release-notes/__tests__/index.test.ts
+++ b/publish-release-notes/__tests__/index.test.ts
@@ -1,11 +1,14 @@
 /**
  * Unit tests for the action's entrypoint, src/index.ts
  */
+import { describe, it, jest, expect } from "@jest/globals";
 
 import * as main from "../src/main";
 
 // Mock the action's entrypoint
-const runMock = jest.spyOn(main, "run").mockImplementation();
+const runMock = jest
+  .spyOn(main, "run")
+  .mockImplementation(async () => Promise.resolve());
 
 describe("index", () => {
   it("calls run when imported", async () => {

--- a/publish-release-notes/__tests__/inputs-helper.test.ts
+++ b/publish-release-notes/__tests__/inputs-helper.test.ts
@@ -1,4 +1,5 @@
 import * as core from "@actions/core";
+import { describe, it, jest, expect } from "@jest/globals";
 
 import * as InputsHelpers from "../src/helpers";
 import { Inputs } from "../src/interfaces";
@@ -7,12 +8,53 @@ jest.mock("@actions/core");
 
 describe("loadInputs", () => {
   it("loads inputs correctly", () => {
+    // Mock core.getInput to return predefined values
+    jest.spyOn(core, "getInput").mockImplementation((name: string) => {
+      switch (name) {
+        case "application-name":
+          return "mocked-application-name";
+        case "dependabot-replacement":
+          return "mocked-dependabot-replacement";
+        case "event-type":
+          return "mocked-event-type";
+        case "github-token":
+          return "mocked-github-token";
+        case "ignore-applications":
+          return "mocked-ignore-applications";
+        case "ignore-commits":
+          return "mocked-ignore-commits";
+        case "product":
+          return "mocked-product";
+        case "release-notes":
+          return JSON.stringify([
+            "mocked-release-notes-1",
+            "mocked-release-notes-2"
+          ]);
+        case "timestamp":
+          return "mocked-timestamp";
+        case "repository-owner":
+          return "mocked-repository-owner";
+        case "repository-name":
+          return "mocked-repository-name";
+        case "sha":
+          return "mocked-sha";
+        case "ignore-products":
+          return "mocked-ignore-products";
+        case "title":
+          return "mocked-title";
+        default:
+          return "";
+      }
+    });
+
     // act
     const {
       applicationName,
       dependabotReplacement,
       eventType,
       githubToken,
+      allowApplications,
+      allowProducts,
       ignoreApplications,
       ignoreCommits,
       ignoreProducts,
@@ -31,10 +73,12 @@ describe("loadInputs", () => {
     expect(dependabotReplacement).toBe("mocked-dependabot-replacement");
     expect(eventType).toBe("mocked-event-type");
     expect(githubToken).toBe("mocked-github-token");
+    expect(allowApplications).toBe("");
+    expect(allowProducts).toBe("");
     expect(ignoreApplications).toBe("mocked-ignore-applications");
     expect(ignoreCommits).toBe("mocked-ignore-commits");
     expect(product).toBe("mocked-product");
-    expect(version).toBe("mocked-version");
+    expect(version).toBe("");
     expect(releaseNotes).toEqual(
       expect.arrayContaining([
         "mocked-release-notes-1",
@@ -46,7 +90,6 @@ describe("loadInputs", () => {
     expect(repositoryName).toBe("mocked-repository-name");
     expect(sha).toBe("mocked-sha");
     expect(ignoreProducts).toBe("mocked-ignore-products");
-    expect(ignoreApplications).toBe("mocked-ignore-applications");
     expect(title).toBe("mocked-title");
   });
 
@@ -68,6 +111,8 @@ describe("loadInputs", () => {
       dependabotReplacement,
       eventType,
       githubToken,
+      allowApplications,
+      allowProducts,
       ignoreApplications,
       ignoreCommits,
       ignoreProducts,
@@ -86,6 +131,8 @@ describe("loadInputs", () => {
     expect(dependabotReplacement).toBe("");
     expect(eventType).toBe("");
     expect(githubToken).toBe("");
+    expect(allowApplications).toBe("");
+    expect(allowProducts).toBe("");
     expect(ignoreApplications).toBe("");
     expect(ignoreCommits).toBe("");
     expect(product).toBe("mocked-product");
@@ -98,5 +145,53 @@ describe("loadInputs", () => {
     expect(ignoreProducts).toBe("");
     expect(ignoreApplications).toBe("");
     expect(title).toBe("mocked-product");
+  });
+
+  it("throws an error when both allow-products and ignore-products are set", () => {
+    jest.spyOn(core, "getInput").mockImplementation((name: string) => {
+      switch (name) {
+        case "release-notes":
+          return JSON.stringify([
+            "mocked-release-notes-1",
+            "mocked-release-notes-2"
+          ]);
+        case "allow-products":
+          return "product1,product2";
+        case "ignore-products":
+          return "product3,product4";
+        default:
+          return "";
+      }
+    });
+
+    expect(() => {
+      InputsHelpers.loadInputs();
+    }).toThrow(
+      "Setting both allow-products and ignore-products is not allowed"
+    );
+  });
+
+  it("throws an error when both allow-applications and ignore-applications are set", () => {
+    jest.spyOn(core, "getInput").mockImplementation((name: string) => {
+      switch (name) {
+        case "release-notes":
+          return JSON.stringify([
+            "mocked-release-notes-1",
+            "mocked-release-notes-2"
+          ]);
+        case "allow-applications":
+          return "app1,app2";
+        case "ignore-applications":
+          return "app3,app4";
+        default:
+          return "";
+      }
+    });
+
+    expect(() => {
+      InputsHelpers.loadInputs();
+    }).toThrow(
+      "Setting both allow-applications and ignore-applications is not allowed"
+    );
   });
 });

--- a/publish-release-notes/__tests__/main.test.ts
+++ b/publish-release-notes/__tests__/main.test.ts
@@ -1,5 +1,7 @@
-import { run } from "../src/main";
 import * as core from "@actions/core";
+import { describe, it, jest, expect, beforeEach } from "@jest/globals";
+
+import { run } from "../src/main";
 import * as InputsHelpers from "../src/helpers/inputs-helper";
 import * as ReleaseNotes from "../src/release-notes";
 
@@ -39,6 +41,8 @@ describe("run", () => {
       repositoryOwner: "test_owner",
       repositoryName: "test_repo",
       sha: "test_sha",
+      allowProducts: "",
+      allowApplications: "",
       ignoreProducts: "",
       ignoreApplications: "",
       title: "TestTitle",
@@ -89,6 +93,8 @@ describe("run", () => {
       repositoryOwner: "test_owner",
       repositoryName: "test_repo",
       sha: "test_sha",
+      allowProducts: "",
+      allowApplications: "",
       ignoreProducts: "",
       ignoreApplications: "",
       title: "TestTitle",
@@ -126,6 +132,8 @@ describe("run", () => {
       repositoryOwner: "test_owner",
       repositoryName: "test_repo",
       sha: "test_sha",
+      allowProducts: "",
+      allowApplications: "",
       ignoreProducts: "IgnoredProduct", // Ignoring this product
       ignoreApplications: "",
       title: "TestTitle",
@@ -162,6 +170,8 @@ describe("run", () => {
       repositoryOwner: "test_owner",
       repositoryName: "test_repo",
       sha: "test_sha",
+      allowApplications: "",
+      allowProducts: "",
       ignoreProducts: "",
       ignoreApplications: "IgnoredApp",
       title: "TestTitle",
@@ -180,6 +190,188 @@ describe("run", () => {
     // assert
     expect(ReleaseNotes.publishReleaseNotes).not.toHaveBeenCalled();
 
+    expect(core.setOutput).toHaveBeenCalledWith(
+      "release-notes-created",
+      "false"
+    );
+  });
+
+  it("should call publishReleaseNotes if product is allowed", async () => {
+    // arrange
+    jest.spyOn(InputsHelpers, "loadInputs").mockImplementation(() => ({
+      applicationName: "TestApp",
+      product: "AllowedProduct",
+      version: "1.0.0",
+      releaseNotes: ["Test release notes"],
+      timestamp: "2024-02-29T12:00:00Z",
+      githubToken: "test_token",
+      repositoryOwner: "test_owner",
+      repositoryName: "test_repo",
+      sha: "test_sha",
+      allowProducts: "AllowedProduct,AnotherProduct",
+      allowApplications: "",
+      ignoreProducts: "",
+      ignoreApplications: "",
+      title: "TestTitle",
+      eventType: "TestEvent",
+      dependabotReplacement: "",
+      ignoreCommits: ""
+    }));
+
+    jest.spyOn(ReleaseNotes, "publishReleaseNotes").mockResolvedValue(true);
+
+    jest.spyOn(core, "setOutput");
+
+    // act
+    await run();
+
+    // assert
+    expect(ReleaseNotes.publishReleaseNotes).toHaveBeenCalledWith(
+      "TestApp",
+      "2024-02-29T12:00:00Z",
+      "test_token",
+      "AllowedProduct",
+      ["Test release notes"],
+      "test_repo",
+      "test_owner",
+      "test_sha",
+      "TestTitle",
+      "1.0.0",
+      "",
+      "TestEvent",
+      ""
+    );
+
+    expect(core.setOutput).toHaveBeenCalledWith(
+      "release-notes-created",
+      "true"
+    );
+  });
+
+  it("should not call publishReleaseNotes if product is not allowed", async () => {
+    // arrange
+    jest.spyOn(InputsHelpers, "loadInputs").mockImplementation(() => ({
+      applicationName: "TestApp",
+      product: "NotAllowedProduct",
+      version: "1.0.0",
+      releaseNotes: ["Test release notes"],
+      timestamp: "2024-02-29T12:00:00Z",
+      githubToken: "test_token",
+      repositoryOwner: "test_owner",
+      repositoryName: "test_repo",
+      sha: "test_sha",
+      allowProducts: "AllowedProduct,AnotherProduct",
+      allowApplications: "",
+      ignoreProducts: "",
+      ignoreApplications: "",
+      title: "TestTitle",
+      eventType: "TestEvent",
+      dependabotReplacement: "",
+      ignoreCommits: ""
+    }));
+
+    jest.spyOn(ReleaseNotes, "publishReleaseNotes").mockResolvedValue(true);
+
+    jest.spyOn(core, "setOutput");
+    jest.spyOn(core, "info");
+
+    // act
+    await run();
+
+    // assert
+    expect(ReleaseNotes.publishReleaseNotes).not.toHaveBeenCalled();
+    expect(core.info).toHaveBeenCalled();
+    expect(core.setOutput).toHaveBeenCalledWith(
+      "release-notes-created",
+      "false"
+    );
+  });
+
+  it("should call publishReleaseNotes if application is allowed", async () => {
+    // arrange
+    jest.spyOn(InputsHelpers, "loadInputs").mockImplementation(() => ({
+      applicationName: "AllowedApp",
+      product: "TestProduct",
+      version: "1.0.0",
+      releaseNotes: ["Test release notes"],
+      timestamp: "2024-02-29T12:00:00Z",
+      githubToken: "test_token",
+      repositoryOwner: "test_owner",
+      repositoryName: "test_repo",
+      sha: "test_sha",
+      allowApplications: "AllowedApp,AnotherApp",
+      allowProducts: "",
+      ignoreProducts: "",
+      ignoreApplications: "",
+      title: "TestTitle",
+      eventType: "TestEvent",
+      dependabotReplacement: "",
+      ignoreCommits: ""
+    }));
+
+    jest.spyOn(ReleaseNotes, "publishReleaseNotes").mockResolvedValue(true);
+
+    jest.spyOn(core, "setOutput");
+
+    // act
+    await run();
+
+    // assert
+    expect(ReleaseNotes.publishReleaseNotes).toHaveBeenCalledWith(
+      "AllowedApp",
+      "2024-02-29T12:00:00Z",
+      "test_token",
+      "TestProduct",
+      ["Test release notes"],
+      "test_repo",
+      "test_owner",
+      "test_sha",
+      "TestTitle",
+      "1.0.0",
+      "",
+      "TestEvent",
+      ""
+    );
+
+    expect(core.setOutput).toHaveBeenCalledWith(
+      "release-notes-created",
+      "true"
+    );
+  });
+
+  it("should not call publishReleaseNotes if application is not allowed", async () => {
+    // arrange
+    jest.spyOn(InputsHelpers, "loadInputs").mockImplementation(() => ({
+      applicationName: "NotAllowedApp",
+      product: "TestProduct",
+      version: "1.0.0",
+      releaseNotes: ["Test release notes"],
+      timestamp: "2024-02-29T12:00:00Z",
+      githubToken: "test_token",
+      repositoryOwner: "test_owner",
+      repositoryName: "test_repo",
+      sha: "test_sha",
+      allowApplications: "AllowedApp,AnotherApp",
+      allowProducts: "",
+      ignoreProducts: "",
+      ignoreApplications: "",
+      title: "TestTitle",
+      eventType: "TestEvent",
+      dependabotReplacement: "",
+      ignoreCommits: ""
+    }));
+
+    jest.spyOn(ReleaseNotes, "publishReleaseNotes").mockResolvedValue(true);
+
+    jest.spyOn(core, "setOutput");
+    jest.spyOn(core, "info");
+
+    // act
+    await run();
+
+    // assert
+    expect(ReleaseNotes.publishReleaseNotes).not.toHaveBeenCalled();
+    expect(core.info).toHaveBeenCalled();
     expect(core.setOutput).toHaveBeenCalledWith(
       "release-notes-created",
       "false"

--- a/publish-release-notes/__tests__/release-notes.test.ts
+++ b/publish-release-notes/__tests__/release-notes.test.ts
@@ -1,5 +1,7 @@
-import * as ReleaseNotes from "../src/release-notes";
 import * as github from "@actions/github";
+import { describe, it, jest, expect } from "@jest/globals";
+
+import * as ReleaseNotes from "../src/release-notes";
 
 describe("filterReleaseNotes", () => {
   it('should filter out items containing "(INTERNAL-COMMIT)"', () => {
@@ -149,7 +151,7 @@ describe("publishReleaseNotes", () => {
     jest.spyOn(github, "getOctokit").mockReturnValue({
       rest: {
         repos: {
-          createDispatchEvent: jest.fn().mockResolvedValue(true)
+          createDispatchEvent: jest.fn().mockImplementation(async () => {})
         }
       }
     } as any);

--- a/publish-release-notes/action.yml
+++ b/publish-release-notes/action.yml
@@ -1,6 +1,7 @@
 name: Publish Release Notes
 description: |
-  "..."
+  Automatically generates and publishes release notes based on provided inputs for applications and products. 
+  This action supports custom configurations to include or exclude specific products, applications, and commits.
 author: Digdir Platform Team
 inputs:
   application-name:
@@ -27,17 +28,31 @@ inputs:
     required: true
     type: string
   repository-owner:
+    description: Owner of the repository
     required: true
     type: string
   repository-name:
+    description: Name of the repository
     required: true
     type: string
   event-type:
+    description: Type of event that triggers the action
     required: true
     type: string
   sha:
     description: Sha of application commit
     required: false
+    type: string
+  allow-products:
+    description: List of products allowed to trigger release notes generation
+    required: false
+    default: ""
+    type: string
+  allow-applications:
+    description: |
+      List of applications allowed to trigger release notes generation
+    required: false
+    default: ""
     type: string
   ignore-products:
     description: Product(s) to ignore when publishing release notes
@@ -49,10 +64,13 @@ inputs:
     required: false
     default: ""
     type: string
-  dependabot-replacement:
+  ignore-commits:
+    description: Commits to ignore when generating release notes
     required: false
     type: string
-  ignore-commits:
+  dependabot-replacement:
+    description: |
+      Replacement text for dependabot-generated commit messages in release notes
     required: false
     type: string
   title:

--- a/publish-release-notes/src/helpers/inputs-helper.ts
+++ b/publish-release-notes/src/helpers/inputs-helper.ts
@@ -20,11 +20,35 @@ export function loadInputs(): Inputs {
   const repositoryName = core.getInput("repository-name", { required: true });
   const eventType = core.getInput("event-type", { required: true });
   const sha = core.getInput("sha") || "";
+  const allowProducts = core.getInput("allow-products") || "";
+  const allowApplications = core.getInput("allow-applications") || "";
   const ignoreProducts = core.getInput("ignore-products") || "";
   const ignoreApplications = core.getInput("ignore-applications") || "";
   const dependabotReplacement = core.getInput("dependabot-replacement") || "";
   const ignoreCommits = core.getInput("ignore-commits") || "";
   const title = core.getInput("title") || product;
+
+  if (
+    allowProducts &&
+    allowProducts.length > 0 &&
+    ignoreProducts &&
+    ignoreProducts.length > 0
+  ) {
+    throw new Error(
+      "Setting both allow-products and ignore-products is not allowed"
+    );
+  }
+
+  if (
+    allowApplications &&
+    allowApplications.length > 0 &&
+    ignoreApplications &&
+    ignoreApplications.length > 0
+  ) {
+    throw new Error(
+      "Setting both allow-applications and ignore-applications is not allowed"
+    );
+  }
 
   return {
     applicationName,
@@ -37,10 +61,12 @@ export function loadInputs(): Inputs {
     repositoryName,
     eventType,
     sha,
+    allowProducts,
+    allowApplications,
     ignoreProducts,
     ignoreApplications,
-    dependabotReplacement,
     ignoreCommits,
+    dependabotReplacement,
     title
   } as Inputs;
 }

--- a/publish-release-notes/src/interfaces/inputs.ts
+++ b/publish-release-notes/src/interfaces/inputs.ts
@@ -9,9 +9,11 @@ export interface Inputs {
   repositoryName: string;
   eventType: string;
   sha: string;
+  allowProducts: string;
+  allowApplications: string;
   ignoreProducts: string;
   ignoreApplications: string;
-  dependabotReplacement: string;
   ignoreCommits: string;
+  dependabotReplacement: string;
   title: string;
 }

--- a/publish-release-notes/src/main.ts
+++ b/publish-release-notes/src/main.ts
@@ -10,6 +10,8 @@ export async function run(): Promise<void> {
       dependabotReplacement,
       eventType,
       githubToken,
+      allowApplications,
+      allowProducts,
       ignoreApplications,
       ignoreCommits,
       ignoreProducts,
@@ -30,6 +32,30 @@ export async function run(): Promise<void> {
       releaseNotes.every(item => item === "")
     ) {
       core.info("release-notes input was empty");
+      core.setOutput("release-notes-created", "false");
+      return;
+    }
+
+    if (
+      allowProducts &&
+      allowProducts.trim().length !== 0 &&
+      !allowProducts.includes(product)
+    ) {
+      core.info(
+        `allow-products does not include the given product (${product})`
+      );
+      core.setOutput("release-notes-created", "false");
+      return;
+    }
+
+    if (
+      allowApplications &&
+      allowApplications.trim().length !== 0 &&
+      !allowApplications.includes(applicationName)
+    ) {
+      core.info(
+        `allow-applications does not include the given application (${applicationName})`
+      );
       core.setOutput("release-notes-created", "false");
       return;
     }


### PR DESCRIPTION
`./dist/index.js` can be ignored