### PR TITLE
MOVE-4247: feat: Support links to 4-letter Jira projects

### DIFF
--- a/get-release-notes/src/helpers/links-helper.ts
+++ b/get-release-notes/src/helpers/links-helper.ts
@@ -18,8 +18,8 @@ export function addJiraLinks(
   baseUrl: string,
   releaseNotes: string[]
 ): string[] {
-  // Regular expression to match the pattern <alpha><alpha><alpha>-<number><number><number>
-  const jiraRegex = /\b[A-Za-z]{2,3}-\d{1,4}\b/g;
+  // Regular expression to match the pattern <alpha>[<alpha><alpha>]<alpha>-<number><number><number>
+  const jiraRegex = /\b[A-Za-z]{2,4}-\d{1,4}\b/g;
 
   // Iterate over each release note
   return releaseNotes.map(note => {


### PR DESCRIPTION
- The regex used for creating Jira links in release notes is modified to support projects with 4-letter names, i.e. MOVE (eFormidling)